### PR TITLE
Flurry: Don't crash if null value passed in parameters

### DIFF
--- a/flurry/ios/src/main/java/org/robovm/pods/flurry/analytics/Flurry.java
+++ b/flurry/ios/src/main/java/org/robovm/pods/flurry/analytics/Flurry.java
@@ -100,7 +100,8 @@ import org.robovm.apple.coregraphics.*;
     protected static NSDictionary<?, ?> stringMapToDictionary(Map<String, String> map) {
         NSDictionary<NSString, NSString> o = new NSMutableDictionary<>();
         for (Map.Entry<String, String> e : map.entrySet()) {
-            o.put(new NSString(e.getKey()), new NSString(e.getValue()));
+            o.put(new NSString(null != e.getKey() ? e.getKey() : ""),
+            	  new NSString(null != e.getValue() ? e.getValue() : ""));
         }
         return o;
     }


### PR DESCRIPTION
If a null String value is passed into the map, Flurry will crash. Replaces null values with an empty string, and replaces keys too just in case. _(The irony of causing a crash because of passing something to Flurry to report on it should be avoided!)_.

_Unfortunately this change was lost from the previous Flurry bindings when converted to a pod, per: https://github.com/BlueRiverInteractive/robovm-ios-bindings/commit/d9cffc0b7bc58c81d9361250758e88cffab72475_